### PR TITLE
Naive fixes for issues #6, #7

### DIFF
--- a/src/luainpython.c
+++ b/src/luainpython.c
@@ -200,6 +200,16 @@ static PyObject *LuaObject_getattr(PyObject *obj, PyObject *attr)
         PyErr_SetString(PyExc_RuntimeError, "lost reference");
         return NULL;
     }
+    
+    if (!lua_isstring(LuaState, -1)
+        && !lua_istable(LuaState, -1)
+        && !lua_isuserdata(LuaState, -1))
+    {
+        lua_pop(LuaState, 1);
+        PyErr_SetString(PyExc_RuntimeError, "not an indexable value");
+        return NULL;
+    }
+
     PyObject *ret = NULL;
     int rc = py_convert(LuaState, attr, 0);
     if (rc) {


### PR DESCRIPTION
Issue #6 - I implemented `del` by just setting the given key to nil. This wouldn't work as might be expected for slices.

Issue #7 - It seems that the panic was due to `isinstance()` attempting to check the function object's `__class__` attribute, but Lua doesn't allow indexing a function. So I added a type check. I think `isinstance()` still works correctly. I call the fix naive because maybe you can mess around with metatables (from Lua code) and make indexing work for functions anyway, and then my type check would prevent `LuaObject_getattr` from working.
