### PR TITLE
Fix python int number conversion

### DIFF
--- a/src/pythoninlua.c
+++ b/src/pythoninlua.c
@@ -85,6 +85,11 @@ int py_convert(lua_State *L, PyObject *o, int withnone)
 #endif
         lua_pushlstring(L, s, len);
         ret = 1;
+#if PY_MAJOR_VERSION < 3
+    } else if (PyInt_Check(o)) {
+        lua_pushnumber(L, (lua_Number)PyInt_AsLong(o));
+        ret = 1;
+#endif
     } else if (PyLong_Check(o)) {
         lua_pushnumber(L, (lua_Number)PyLong_AsLong(o));
         ret = 1;


### PR DESCRIPTION
Conversion from python int to lua number doesn't work for python code in
lua in case of python 2.7

The error can easily be reproduced via the following code:

  import lua
  script='i = python.eval("int(2)")\n' \
         'print(type(i))'
  lua.execute(script)

It is a regression introduced in commit ba53e14b7047a "Ported Lunatic to
Python 3.3.", because in python2.7 there are distinct types for int and
long in python.

The commit mentioned above removed the PyInt_check code, which is correct
for python 3.x code. In python2.7 this is still needed, otherwise a python
int is converted to userdata in lua.

This commit reintroduces the necessary PyInt_Check to ensure an int is
correctly converted to lua number and makes it conditional on the python
major version.
