### PR TITLE
Fixed compilation issues on linux in CMAKE files.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.8)
+cmake_minimum_required(VERSION 2.8.12)
 
 set(CMAKE_BUILD_TYPE_INIT "Release")
 set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin)
@@ -6,7 +6,7 @@ set(LIBRARY_OUTPUT_PATH ${EXECUTABLE_OUTPUT_PATH})
 
 project(Lunatic)
 
-find_package(Lua51 REQUIRED)
+find_package(Lua 5.2 REQUIRED)
 find_package(PythonLibs REQUIRED)
 
 include_directories(${LUA_INCLUDE_DIR})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,3 +4,6 @@ endif (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
 add_definitions(-DLUA_LIB)
 
 add_library(src OBJECT luainpython.c pythoninlua.c)
+set_target_properties(src PROPERTIES 
+                          POSITION_INDEPENDENT_CODE TRUE)
+


### PR DESCRIPTION
CMAKE spits configuration issue related to not finding Lua 5.2 and also while building the project, make stops at linking step because compiled objects are not position independent.

I have fixed these issues in CMAKE files and it is currently working properly on linux. I haven't tested it on windows but changes I have made should work there. 