### PR TITLE
Operators, indexing and named parameters from Lua

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(LIBRARY_OUTPUT_PATH ${EXECUTABLE_OUTPUT_PATH})
 
 project(Lunatic)
 
-find_package(Lua 5.2 REQUIRED)
+find_package(Lua 5.1 REQUIRED)
 find_package(PythonLibs REQUIRED)
 
 include_directories(${LUA_INCLUDE_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.0.0)
 
 set(CMAKE_BUILD_TYPE_INIT "Release")
 set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin)

--- a/src/pythoninlua.c
+++ b/src/pythoninlua.c
@@ -133,8 +133,9 @@ static int py_object_call(lua_State *L)
         lua_pushnil(L);  /* first key */
         while (lua_next(L, 2) != 0) {
             if (lua_isnumber(L, -2)) {
-                nargs = max(nargs, lua_tointeger(L, -2));
-	           }
+                int i = lua_tointeger(L, -2);
+                nargs = i < nargs ? nargs : i;
+            }
             lua_pop(L, 1);
         }
         args = PyTuple_New(nargs);
@@ -142,7 +143,7 @@ static int py_object_call(lua_State *L)
             PyErr_Print();
             return luaL_error(L, "failed to create arguments tuple");
         }
-	       pKywdArgs = PyDict_New();    
+        pKywdArgs = PyDict_New();    
         if (!pKywdArgs) {
             Py_DECREF(args);
             PyErr_Print();
@@ -151,22 +152,22 @@ static int py_object_call(lua_State *L)
         lua_pushnil(L);  /* first key */
         while (lua_next(L, 2) != 0) {
             if (lua_isnumber(L, -2)) {
-	               PyObject *arg = LuaConvert(L, -1);
+                PyObject *arg = LuaConvert(L, -1);
                 if (!arg) {
                     Py_DECREF(args);
                     Py_DECREF(pKywdArgs);
                     return luaL_error(L, "failed to convert argument #%d", lua_tointeger(L, -2));
                 }
-	               PyTuple_SetItem(args, lua_tointeger(L, -2)-1, arg);
-	           }
-	           else if (lua_isstring(L, -2)) {
-	               PyObject *arg = LuaConvert(L, -1);
+                PyTuple_SetItem(args, lua_tointeger(L, -2)-1, arg);
+            }
+            else if (lua_isstring(L, -2)) {
+                PyObject *arg = LuaConvert(L, -1);
                 if (!arg) {
                     Py_DECREF(args);
                     Py_DECREF(pKywdArgs);
-		                  return luaL_error(L, "failed to convert argument '%s'", lua_tostring(L, -2));
+                    return luaL_error(L, "failed to convert argument '%s'", lua_tostring(L, -2));
                 }
-		              PyDict_SetItemString(pKywdArgs, lua_tostring(L, -2), arg);
+                PyDict_SetItemString(pKywdArgs, lua_tostring(L, -2), arg);
                 Py_DECREF(arg);
             }
             lua_pop(L, 1);

--- a/src/pythoninlua.c
+++ b/src/pythoninlua.c
@@ -209,7 +209,7 @@ static int py_object_newindex(lua_State *L)
         return luaL_argerror(L, 1, "not a python object");
     }
 
-    if (obj->asindx)
+    if (obj->asindx || lua_type(L, 2)!=LUA_TSTRING)
         return _p_object_newindex_set(L, obj, 2, 3);
 
     attr = luaL_checkstring(L, 2);
@@ -282,7 +282,7 @@ static int py_object_index(lua_State *L)
         return luaL_argerror(L, 1, "not a python object");
     }
 
-    if (obj->asindx)
+    if (obj->asindx || lua_type(L, 2)!=LUA_TSTRING)
         return _p_object_index_get(L, obj, 2);
 
     attr = luaL_checkstring(L, 2);

--- a/src/pythoninlua.c
+++ b/src/pythoninlua.c
@@ -341,12 +341,112 @@ static int py_object_tostring(lua_State *L)
     return 1;
 }
 
+static int py_object_mul(lua_State *L)
+{
+    int r=0;
+    PyObject *value;
+    if (lua_isuserdata(L, 1))
+    { py_object *obj = (py_object*) luaL_checkudata(L, 1, POBJECT);
+      lua_remove(L, 1);
+      value = PyObject_GetAttrString(obj->o, "__mul__");
+    }
+    else
+    { py_object *obj = (py_object*) luaL_checkudata(L, 2, POBJECT);
+      lua_remove(L, 2);
+      value = PyObject_GetAttrString(obj->o, "__rmul__");
+    }
+    r = py_object_call2(L, value);
+    Py_DECREF(value);
+    return r;
+}
+
+static int py_object_div(lua_State *L)
+{
+    int r=0;
+    PyObject *value;
+    if (lua_isuserdata(L, 1))
+    { py_object *obj = (py_object*) luaL_checkudata(L, 1, POBJECT);
+      lua_remove(L, 1);
+      value = PyObject_GetAttrString(obj->o, "__div__");
+    }
+    else
+    { py_object *obj = (py_object*) luaL_checkudata(L, 2, POBJECT);
+      lua_remove(L, 2);
+      value = PyObject_GetAttrString(obj->o, "__rdiv__");
+    }
+    r = py_object_call2(L, value);
+    Py_DECREF(value);
+    return r;
+}
+
+static int py_object_add(lua_State *L)
+{
+    int r=0;
+    PyObject *value;
+    if (lua_isuserdata(L, 1))
+    { py_object *obj = (py_object*) luaL_checkudata(L, 1, POBJECT);
+      lua_remove(L, 1);
+      value = PyObject_GetAttrString(obj->o, "__add__");
+    }
+    else
+    { py_object *obj = (py_object*) luaL_checkudata(L, 2, POBJECT);
+      lua_remove(L, 2);
+      value = PyObject_GetAttrString(obj->o, "__radd__");
+    }
+    r = py_object_call2(L, value);
+    Py_DECREF(value);
+    return r;
+}
+
+static int py_object_sub(lua_State *L)
+{
+    int r=0;
+    PyObject *value;
+    if (lua_isuserdata(L, 1))
+    { py_object *obj = (py_object*) luaL_checkudata(L, 1, POBJECT);
+      lua_remove(L, 1);
+      value = PyObject_GetAttrString(obj->o, "__sub__");
+    }
+    else
+    { py_object *obj = (py_object*) luaL_checkudata(L, 2, POBJECT);
+      lua_remove(L, 2);
+      value = PyObject_GetAttrString(obj->o, "__rsub__");
+    }
+    r = py_object_call2(L, value);
+    Py_DECREF(value);
+    return r;
+}
+
+static int py_object_pow(lua_State *L)
+{
+    int r=0;
+    PyObject *value;
+    if (lua_isuserdata(L, 1))
+    { py_object *obj = (py_object*) luaL_checkudata(L, 1, POBJECT);
+      lua_remove(L, 1);
+      value = PyObject_GetAttrString(obj->o, "__pow__");
+    }
+    else
+    { py_object *obj = (py_object*) luaL_checkudata(L, 2, POBJECT);
+      lua_remove(L, 2);
+      value = PyObject_GetAttrString(obj->o, "__rpow__");
+    }
+    r = py_object_call2(L, value);
+    Py_DECREF(value);
+    return r;
+}
+
 static const luaL_Reg py_object_lib[] = {
     {"__call",  py_object_call},
     {"__index", py_object_index},
     {"__newindex",  py_object_newindex},
     {"__gc",    py_object_gc},
     {"__tostring",  py_object_tostring},
+    {"__mul",   py_object_mul},
+    {"__div",   py_object_div},
+    {"__add",   py_object_add},
+    {"__sub",   py_object_sub},
+    {"__pow",   py_object_pow},
     {NULL, NULL}
 };
 


### PR DESCRIPTION
Hi,

these commits would add operators on python objects from Lua (2 commits, my mistake), default non-string Lua indexing to python indexing, and allow calling a python method with named parameters. The latter change has a few indendation errors due to copy/paste from editor. The branch has been tested.