### PR TITLE
Should not generate error if attribute not found on python object

### DIFF
--- a/src/pythoninlua.c
+++ b/src/pythoninlua.c
@@ -329,7 +329,8 @@ static int py_object_index(lua_State *L)
         Py_DECREF(value);
     } else {
         PyErr_Clear();
-        // luaL_error(L, "unknown attribute in python object");
+        lua_pushnil(L);
+        ret = 1;
     }
 
     return ret;

--- a/src/pythoninlua.c
+++ b/src/pythoninlua.c
@@ -329,7 +329,7 @@ static int py_object_index(lua_State *L)
         Py_DECREF(value);
     } else {
         PyErr_Clear();
-        luaL_error(L, "unknown attribute in python object");
+        // luaL_error(L, "unknown attribute in python object");
     }
 
     return ret;


### PR DESCRIPTION
IMHO, if the attribute is not found on python object it should just return nil otherwise it would break the entire lua state machine.