### PR TITLE
Bug fix: Set 'python' global to newly created lib after loading

### DIFF
--- a/src/pythoninlua.c
+++ b/src/pythoninlua.c
@@ -667,5 +667,8 @@ LUA_API int luaopen_python(lua_State *L)
 
     lua_setfield(L, -2, "none"); /* python.none */
 
+    /* Set 'python' global to newly loaded lib */
+    lua_setglobal(L, "python");
+
     return 1;
 }


### PR DESCRIPTION
This resolves the issue with the python global being undefined after the lib is required.