### PR TITLE
Made changes to CMakeLists.txt to work with Python3 and Python2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.0)
+cmake_minimum_required(VERSION 3.12.0)
 
 set(CMAKE_BUILD_TYPE_INIT "Release")
 set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,28 +4,26 @@ set(CMAKE_BUILD_TYPE_INIT "Release")
 set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin)
 set(LIBRARY_OUTPUT_PATH ${EXECUTABLE_OUTPUT_PATH})
 
-
 project(Lunatic)
 
 find_package(Lua        5.1 REQUIRED)
-find_package(PythonLibs 2.7 REQUIRED)
-
+find_package(Python REQUIRED COMPONENTS Interpreter Development)
 
 add_subdirectory(src)
 
 add_library(python MODULE $<TARGET_OBJECTS:src>)
-set_target_properties(python PROPERTIES 
+set_target_properties(python PROPERTIES
                              PREFIX "")
 
 add_library(lua MODULE $<TARGET_OBJECTS:src>)
 if (WIN32)
-  set_target_properties(lua PROPERTIES 
+  set_target_properties(lua PROPERTIES
                             PREFIX ""
                             SUFFIX ".pyd")
 else (WIN32)
-  set_target_properties(lua PROPERTIES 
+  set_target_properties(lua PROPERTIES
                             PREFIX "")
 endif (WIN32)
 
-target_link_libraries(lua     ${LUA_LIBRARIES} ${PYTHON_LIBRARIES})
-target_link_libraries(python  ${LUA_LIBRARIES} ${PYTHON_LIBRARIES})
+target_link_libraries(lua     ${LUA_LIBRARIES} ${Python_LIBRARIES})
+target_link_libraries(python  ${LUA_LIBRARIES} ${Python_LIBRARIES})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,8 +1,8 @@
 add_library(src OBJECT luainpython.c pythoninlua.c)
-set_target_properties(src PROPERTIES 
+set_target_properties(src PROPERTIES
                           POSITION_INDEPENDENT_CODE TRUE)
 
-target_include_directories(src PRIVATE ${LUA_INCLUDE_DIR} ${PYTHON_INCLUDE_DIR})
+target_include_directories(src PRIVATE ${LUA_INCLUDE_DIR} ${Python_INCLUDE_DIRS})
 
 target_compile_definitions(src PRIVATE LUA_LIB)
 if (WIN32)
@@ -10,7 +10,7 @@ if (WIN32)
 endif (WIN32)
 
 if (UNIX)
-  get_filename_component(PYTHON_LIBRT ${PYTHON_LIBRARIES} NAME)
+  get_filename_component(PYTHON_LIBRT ${Python_LIBRARIES} NAME)
   target_compile_definitions(src PRIVATE PYTHON_LIBRT=${PYTHON_LIBRT})
 endif (UNIX)
 


### PR DESCRIPTION
One minor thing after the set of changes in the previous pull request, pertaining to extracting and formatting Python exception in lua.

The cmake file looks for Python 2.7. Currently Python 3 is more in vogue.

There is a [cmake module FindPython](https://cmake.org/cmake/help/v3.12/module/FindPython.html) available which first looks for availability of Python3 and then for Python2 in that order and locates appropriate development environment and libraries.

This change makes the build go through without any changes to CMakeLists.txt file, which otherwise was becoming necessary for Python 3 environments.

Request review and merger of this.

