### PR TITLE
Add GitHub Action workflow to run lua tests/test_py.lua

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: ci
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+jobs:
+  ci:
+    strategy:
+      fail-fast: false  # https://github.com/actions/runner-images#available-images
+      matrix:  # https://www.lua.org/versions.html
+        os: [ubuntu-26.04, ubuntu-26.04-arm]
+        lua-version: [5.1, 5.2, 5.3, 5.4]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - run: |
+          sudo apt-get update
+          sudo apt-get install -y lua${{ matrix.lua-version }} liblua${{ matrix.lua-version }}-dev luarocks
+      - run: lua -v && luarocks --version  # Lua 5.x.x Luarocks 3.8.0 (not 3.13.0!)
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: 3.x
+          pip-install: --editable .
+      - run: luarocks --lua-version=${{ matrix.lua-version }} lint lunatic-python-scm-0.rockspec
+      - run: luarocks --lua-version=${{ matrix.lua-version }} lint rockspecs/lunatic-python-1.0-1.rockspec
+      - run: luarocks --lua-version=${{ matrix.lua-version }} --local make
+      - run: luarocks --lua-version=${{ matrix.lua-version }} show lunatic-python
+      # lua5.2: https://github.com/bastibe/lunatic-python/issues/98  
+      # lua5.4: https://github.com/bastibe/lunatic-python/issues/99  
+      # lua5.5: https://github.com/bastibe/lunatic-python/issues/100  
+      - run: lua${{ matrix.lua-version }} tests/test_py.lua


### PR DESCRIPTION
> [!NOTE]
> **This pull-request is a continuation of #96**

Add a GitHub Action to run `lua tests/test_py.lua` so we can focus on fixes for:
* #98 
* #99 
* #100

```yaml
- if: matrix.lua-version == '5.1' || matrix.lua-version == '5.3'
  run: lua${{ matrix.lua-version }} tests/test_py.lua
```
All 10 GHA runs pass on both `ubuntu-26.04` and `ubuntu-26.04-arm`.

I believe that this is the best GitHub Actions PR to review and merge.  It runs a test that passes and can provide feedback for three issues that can then be fixed and closed.  Once this is merged, we will have Lua builds with continuous integration basic guardrails in place, and any other GHA PRs can be rebased.