### PR TITLE
Enable `pip install --editable .` on macOS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,19 +1,19 @@
 #!/usr/bin/python
 
-import sys
 import os
+import sys
+from distutils.sysconfig import get_python_lib
 
-if sys.version > '3':
-    PY3 = True
-else:
-    PY3 = False
+PY3 = sys.version_info >= (3, 0)
 
 if PY3:
-    import subprocess as commands
+    from setuptools import Extension, setup
+    from subprocess import getstatusoutput
+    from sysconfig import get_config_var, get_python_version
 else:
-    import commands
-from distutils.core import setup, Extension
-from distutils.sysconfig import get_config_var, get_python_lib, get_python_version
+    from commands import getstatusoutput
+    from distutils.core import setup, Extension
+    from distutils.sysconfig import get_config_var, get_python_version
 
 if os.path.isfile("MANIFEST"):
     os.unlink("MANIFEST")
@@ -22,7 +22,7 @@ lua_versions = ["5.5", "5.4", "5.3", "5.2", "5.1"]
 
 LUAVERSION = None
 for version in lua_versions:
-	presult, poutput = commands.getstatusoutput("pkg-config --exists lua" + str(version))
+	presult, poutput = getstatusoutput("pkg-config --exists lua" + str(version))
 	if presult == 0:
 		LUAVERSION = version
 		break
@@ -43,7 +43,7 @@ def pkgconfig(*packages):
 
     combined_pcoutput = ''
     for package in packages:
-        (pcstatus, pcoutput) = commands.getstatusoutput(
+        (pcstatus, pcoutput) = getstatusoutput(
             "pkg-config --libs --cflags %s" % package)
         if pcstatus == 0:
             combined_pcoutput += ' ' + pcoutput


### PR DESCRIPTION
> Could you confirm that pip install --editable . works on macOS as well now?
* https://github.com/bastibe/lunatic-python/pull/96#discussion_r3443353508

With the proposed change:
% `uv venv`
% `source .venv/bin/activate`
% `uv pip install --editable .`
% `python`
Python 3.14.6 (main, Jun 11 2026, 03:55:33) [Clang 22.1.3 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
```python
>>> import lua
... lg = lua.globals()
... print(f"{lg = }")
... print(f"{lg.string = }")
... print(f"{lg.string.lower = }")
... print(f"{lg.string.lower('Hello world!') = }")
... assert lg.string.lower('Hello world!') != 'Hello world!'
... assert lg.string.lower('Hello world!') == 'hello world!'
...
```
lg = <Lua table at 0x105eea5a0>
lg.string = <Lua table at 0xb390b8930>
lg.string.lower = <Lua function at 0x1059812a0>
lg.string.lower('Hello world!') = 'hello world!'