### PR TITLE
Enable `pip install --editable .` on macOS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,9 @@ else:
 from distutils.core import setup, Extension
 from distutils.sysconfig import get_config_var, get_python_lib, get_python_version
 
+if not os.environ.get("PKG_CONFIG_PATH"):  # See `python3.14 -m sysconfig | grep LIBPC`
+    os.environ["PKG_CONFIG_PATH"] = get_config_var("LIBPC")
+
 if os.path.isfile("MANIFEST"):
     os.unlink("MANIFEST")
 


### PR DESCRIPTION
> Could you confirm that `pip install --editable .` works on macOS as well now?
* https://github.com/bastibe/lunatic-python/pull/96#discussion_r3443353508

 See `python3.14 -m sysconfig | grep LIBPC`

```diff
+ if not os.environ.get("PKG_CONFIG_PATH"):
+    os.environ["PKG_CONFIG_PATH"] = get_config_var("LIBPC")
```
With the proposed change:
% `uv venv`
% `source .venv/bin/activate`
% `uv pip install --editable .`
% `python`
Python 3.14.6 (main, Jun 11 2026, 03:55:33) [Clang 22.1.3 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
```python
>>> import lua
... lg = lua.globals()
... print(f"{lg = }")
... print(f"{lg.string = }")
... print(f"{lg.string.lower = }")
... print(f"{lg.string.lower('Hello world!') = }")
... assert lg.string.lower('Hello world!') != 'Hello world!'
... assert lg.string.lower('Hello world!') == 'hello world!'
...
```
lg = <Lua table at 0x105eea5a0>
lg.string = <Lua table at 0xb390b8930>
lg.string.lower = <Lua function at 0x1059812a0>
lg.string.lower('Hello world!') = 'hello world!'